### PR TITLE
Looks for global_stats.json rather than simulation.log

### DIFF
--- a/src/main/java/com/excilys/ebi/gatling/jenkins/GatlingPublisher.java
+++ b/src/main/java/com/excilys/ebi/gatling/jenkins/GatlingPublisher.java
@@ -87,7 +87,7 @@ public class GatlingPublisher extends Recorder {
 	}
 
 	private FilePath saveFullReport(FilePath workspace, File rootDir) throws IOException, InterruptedException {
-		FilePath[] files = workspace.list("**/simulation.log");
+		FilePath[] files = workspace.list("**/global_stats.json");
 
 		if(files.length == 0) {
 			throw new IllegalArgumentException("Could not find a Gatling report in results folder.");
@@ -95,7 +95,7 @@ public class GatlingPublisher extends Recorder {
 			throw new IllegalArgumentException("Found more than one Gatling report in results folder, make sure results folder is cleared between two builds.");
 		}
 
-		FilePath parent = files[0].getParent();
+		FilePath parent = files[0].getParent().getParent();
 		String name = parent.getName();
 		File allSimulationsDirectory = new File(rootDir, "simulations");
 		if (!allSimulationsDirectory.exists())


### PR DESCRIPTION
This allows one to run several Gatling simulations, with only one that actually generates reports to be analyzed by the Gatling Jenkins plugin.

Seen with @pdalpra yesterday.
