### PR TITLE
Cleanup of report rendering handler

### DIFF
--- a/src/main/java/com/excilys/ebi/gatling/jenkins/BuildSimulation.java
+++ b/src/main/java/com/excilys/ebi/gatling/jenkins/BuildSimulation.java
@@ -18,6 +18,11 @@ package com.excilys.ebi.gatling.jenkins;
 
 import hudson.FilePath;
 
+/**
+ * This class is basically just a struct to hold information about one
+ * or more gatling simulations that were archived for a given
+ * instance of {@link GatlingBuildAction}.
+ */
 public class BuildSimulation {
     private final String simulationName;
     private final RequestReport requestReport;

--- a/src/main/java/com/excilys/ebi/gatling/jenkins/GatlingBuildAction.java
+++ b/src/main/java/com/excilys/ebi/gatling/jenkins/GatlingBuildAction.java
@@ -61,100 +61,15 @@ public GatlingBuildAction(AbstractBuild<?, ?> build, List<BuildSimulation> sims)
 
     /**
      * This method is called dynamically for any HTTP request to our plugin's
-     * URL followed by "/report".
+     * URL followed by "/report/SomeSimulationName".
      *
-     * If there are no tokens in the URL after "/report", it will just
-     * display the index page for the Build action (which will display a list
-     * of available reports with hyperlinks).
+     * It returns a new instance of {@link ReportRenderer}, which contains
+     * the actual logic for rendering a report.
      *
-     * If there is one token in the URL after "/report" (e.g. "/report/MySimId"),
-     * the token is assumed to be the simulation ID of a given simulation, and
-     * it will use the "report.jelly" template to render that report.
-     *
-     * If there is more than one token in the URL after "/report" (e.g.
-     * "/report/MySimId/source/index.html"), the code assumes that we're rendering
-     * individual HTML / CSS / image components of the report, so it basically
-     * passes through to the files on disk in the archived report directory.
-     *
-     * @param request
-     * @param response
-     * @throws IOException
-     * @throws ServletException
+     * @param simName
      */
-    public void doReport(StaplerRequest request, StaplerResponse response) throws IOException, ServletException {
-
-        String rest = request.getRestOfPath();
-        if (rest.startsWith("/")) {
-            rest = rest.substring(1);
-        }
-
-        // break apart the URL to determine what we're rendering
-        String[] tokens = rest.split("/");
-        String simName;
-        switch (tokens.length) {
-            case 1:
-                // if there's only one token, it's either an empty string
-                // or a sim name.
-                simName = tokens[0];
-                if (simName.equals("")) {
-                    // if it's the empty string, then someone browsed directly
-                    // to "/report" for this build, so we will just show
-                    // the index page for the build action.
-                    ForwardToView forward = new ForwardToView(this, "index.jelly");
-                    forward.generateResponse(request, response, this);
-                    break;
-                } else {
-                    // otherwise we have a sim name, so we'll render the jelly
-                    // template for an individual report
-                    ForwardToView forward = new ForwardToView(this, "report.jelly")
-                            .with("simName", simName);
-                    forward.generateResponse(request, response, this);
-                    break;
-                }
-            default:
-                // if we get here then we're probably trying to render some
-                // actual report content
-                simName = tokens[0];
-                String subItem = tokens[1];
-
-                // for now, we only support "source" as the next item in the
-                // URL after "/report/MySimId".  If they requested something
-                // else, we just return because we're not currently capable of
-                // rendering anything else.  We might want to log a warning or
-                // something.
-                if (!subItem.equals("source")) return;
-
-                // If we get here, we know we're trying to render some actual
-                // HTML/CSS/image component of a report.
-
-                // First we find the particular simulation that is being requested
-                BuildSimulation sim = this.getSimulation(simName);
-
-                // This part is nasty and I'd like to find a better way to handle
-                // it, but I haven't been able to find anything yet.  The problem
-                // is that the Stapler `DirectoryBrowserSupport` (which we're
-                // using to basically pass through directly to files in the archived
-                // report directory on disk) needs for the `request.getRestOfPath()`
-                // method to return a base path that maps to files that actually
-                // exist in our report directory.  In our case, we really want that
-                // to just be something like "/index.html", but it currently
-                // contains something like "MySimId/source/index.html".  So we
-                // need to tweak the request to remove the tokens that we've already
-                // handled in our code.  This is easy to do if we cast the
-                // request object to its actual type, but that's probably not
-                // a supported API and could break in the future.
-                RequestImpl reqImpl = (RequestImpl)request;
-                // advance past the "MySimId" token
-                reqImpl.tokens.next();
-                // advance past the "source" token
-                reqImpl.tokens.next();
-
-                // Now our request has the appropriate relative path and
-                // we can just pass through to `DirectoryBrowserSupport`.
-                DirectoryBrowserSupport dbs = new DirectoryBrowserSupport(this, sim.getSimulationDirectory(), sim.getSimulationName(), null, false);
-                dbs.generateResponse(request, response, this);
-                break;
-        }
+    public ReportRenderer getReport(String simName) {
+        return new ReportRenderer(this, getSimulation(simName));
     }
 
 

--- a/src/main/java/com/excilys/ebi/gatling/jenkins/ReportRenderer.java
+++ b/src/main/java/com/excilys/ebi/gatling/jenkins/ReportRenderer.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2011-2012 eBusiness Information, Groupe Excilys (www.excilys.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.excilys.ebi.gatling.jenkins;
+
+import hudson.model.DirectoryBrowserSupport;
+import org.kohsuke.stapler.ForwardToView;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+/**
+ * This class is used by the {@link GatlingBuildAction} to handle the rendering
+ * of gatling reports.
+ */
+public class ReportRenderer {
+
+    private GatlingBuildAction action;
+    private BuildSimulation simulation;
+
+    public ReportRenderer(GatlingBuildAction gatlingBuildAction, BuildSimulation simulation) {
+        this.action = gatlingBuildAction;
+        this.simulation = simulation;
+    }
+
+    /**
+     * This method will be called when there are no remaining URL tokens to
+     * process after {@link GatlingBuildAction} has handled the initial
+     * `/report/MySimulationName` prefix.  It renders the `report.jelly`
+     * template inside of the Jenkins UI.
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doIndex(StaplerRequest request, StaplerResponse response)
+            throws IOException, ServletException {
+        ForwardToView forward = new ForwardToView(action, "report.jelly")
+                .with("simName", simulation.getSimulationName());
+        forward.generateResponse(request, response, action);
+    }
+
+    /**
+     * This method will be called for all URLs that are routed here by
+     * {@link GatlingBuildAction} with a prefix of `/source`.
+     *
+     * All such requests basically result in the servlet simply serving
+     * up content files directly from the archived simulation directory
+     * on disk.
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doSource(StaplerRequest request, StaplerResponse response)
+            throws IOException, ServletException {
+        DirectoryBrowserSupport dbs = new DirectoryBrowserSupport(action,
+                simulation.getSimulationDirectory(),
+                simulation.getSimulationName(), null, false);
+        dbs.generateResponse(request, response, action);
+    }
+}

--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingBuildAction/report.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingBuildAction/report.jelly
@@ -7,9 +7,9 @@
 		</l:side-panel>
 		<l:main-panel>
 			<h1>
-				<a href="${simName}/source" target="_blank">${%OpenNewPage}</a>
+				<a href="source" target="_blank">${%OpenNewPage}</a>
 			</h1>
-			<iframe id="reportFrame" src="${simName}/source" width="100%" height="100%" frameborder="0"
+			<iframe id="reportFrame" src="source" width="100%" height="100%" frameborder="0"
 			        onload="resizeReportFrame()"></iframe>
 			<script type="text/javascript">
 				function resizeReportFrame() {


### PR DESCRIPTION
Thanks to some input from the Jenkins mailing list, I discovered
a much, much cleaner way to implement the request routing
for serving up the Gatling reports in the Jenkins UI.

This commit provides no functional changes, but the code is much
cleaner and more maintainable.
