### PR TITLE
(feature) Make graph data points clickable

### DIFF
--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
@@ -6,5 +6,19 @@
 			<g:graph id="dashboardGatling" seriesNames="${action.dashboardGraph.seriesNamesJSON}"
 			         data="${action.dashboardGraph.seriesJSON}" yAxisUnit="ms" height="400px" width="500px"/>
 		</div>
+
+        <script>
+            var dashboardSeriesNames = ${action.dashboardGraph.seriesNamesJSON};
+            var dashboardSeriesValues = ${action.dashboardGraph.seriesJSON};
+
+            $$('#dashboardGatling').bind('jqplotDataClick',
+                function (ev, seriesIndex, pointIndex, data) {
+                    var xAxisArray = dashboardSeriesValues[seriesIndex].reverse();
+                    var url = xAxisArray[pointIndex][0] + "/gatling/report/" + dashboardSeriesNames[seriesIndex].label + "/";
+                    var win = window.open(url, '_blank');
+                    win.focus();
+                }
+            );
+        </script>
 	</j:if>
 </j:jelly>

--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/index.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/index.jelly
@@ -31,6 +31,44 @@
                     </j:forEach>
 				</j:forEach>
 			</ul>
+
+            <script>
+                var meanResponseSeriesNames = ${it.meanResponseTimeGraph.seriesNamesJSON};
+                var meanResponseSeriesValues = ${it.meanResponseTimeGraph.seriesJSON};
+
+                $$('#meanResponseTime').bind('jqplotDataClick',
+                    function (ev, seriesIndex, pointIndex, data) {
+                        var xAxisArray = meanResponseSeriesValues[seriesIndex].reverse();
+                        var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + meanResponseSeriesNames[seriesIndex].label + "/";
+                        var win = window.open(url, '_blank');
+                        win.focus();
+                    }
+                );
+
+                var responseTimeSeriesNames = ${it.percentileResponseTimeGraph.seriesNamesJSON};
+                var responseTimeSeriesValues = ${it.percentileResponseTimeGraph.seriesJSON};
+
+                $$('#responseTimePercentile').bind('jqplotDataClick',
+                    function (ev, seriesIndex, pointIndex, data) {
+                        var xAxisArray = responseTimeSeriesValues[seriesIndex].reverse();
+                        var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + responseTimeSeriesNames[seriesIndex].label + "/";
+                        var win = window.open(url, '_blank');
+                        win.focus();
+                    }
+                );
+
+                var requestKOSeriesNames = ${it.requestKOPercentageGraph.seriesNamesJSON};
+                var requestKOSeriesValues = ${it.requestKOPercentageGraph.seriesJSON};
+
+                $$('#requestKO').bind('jqplotDataClick',
+                    function (ev, seriesIndex, pointIndex, data) {
+                        var xAxisArray = responseTimeSeriesValues[seriesIndex].reverse();
+                        var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + requestKOSeriesNames[seriesIndex].label + "/";
+                        var win = window.open(url, '_blank');
+                        win.focus();
+                    }
+                );
+            </script>
 		</l:main-panel>
 	</l:layout>
 </j:jelly>


### PR DESCRIPTION
Prior to this commit, the data points within the gatling graphs only
responded to a mouse hovering over an individual data point with a tool
tip. This commit changes that by allowing the user to click on a data
point, which will then open a new window and take them to the specific
build the data point is related to.
