### PR TITLE
Adding endpoints to fetch json data for graphs

### DIFF
--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/mean_json.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/mean_json.jelly
@@ -1,0 +1,4 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
+         xmlns:g="/com/excilys/ebi/gatling/jenkins/tags">
+  ${it.meanResponseTimeGraph.seriesJSON}
+</j:jelly>

--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/per95_json.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/per95_json.jelly
@@ -1,0 +1,4 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
+         xmlns:g="/com/excilys/ebi/gatling/jenkins/tags">
+  ${it.percentileResponseTimeGraph.seriesJSON}
+</j:jelly>

--- a/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/reqKO_json.jelly
+++ b/src/main/resources/com/excilys/ebi/gatling/jenkins/GatlingProjectAction/reqKO_json.jelly
@@ -1,0 +1,4 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
+         xmlns:g="/com/excilys/ebi/gatling/jenkins/tags">
+  ${it.requestKOPercentageGraph.seriesJSON}
+</j:jelly>


### PR DESCRIPTION
We are building a performance monitoring dashboard which gets performance data from jenkins builds. To plot this data we required the endpoints which can provide json data for each graph. Hopefully this is useful for others too so would like you to merge this PR.
