### PR TITLE
Work around conflict with jQuery jenkins plugin

### DIFF
--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
@@ -10,7 +10,7 @@
         <script>
             var dashboardSeriesNames = ${action.dashboardGraph.seriesNamesJSON};
             var dashboardSeriesValues = ${action.dashboardGraph.seriesJSON};
-						jQuery('#dashboardGatling').bind('jqplotDataClick',
+						jQueryGatling('#dashboardGatling').bind('jqplotDataClick',
                 function (ev, seriesIndex, pointIndex, data) {
                     var xAxisArray = dashboardSeriesValues[seriesIndex].reverse();
                     var url = xAxisArray[pointIndex][0] + "/gatling/report/" + dashboardSeriesNames[seriesIndex].label + "/";

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/index.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/index.jelly
@@ -36,7 +36,7 @@
                 var meanResponseSeriesNames = ${it.meanResponseTimeGraph.seriesNamesJSON};
                 var meanResponseSeriesValues = ${it.meanResponseTimeGraph.seriesJSON};
 
-                jQuery('#meanResponseTime').bind('jqplotDataClick',
+                jQueryGatling('#meanResponseTime').bind('jqplotDataClick',
                     function (ev, seriesIndex, pointIndex, data) {
                         var xAxisArray = meanResponseSeriesValues[seriesIndex].reverse();
                         var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + meanResponseSeriesNames[seriesIndex].label + "/";
@@ -48,7 +48,7 @@
                 var responseTimeSeriesNames = ${it.percentileResponseTimeGraph.seriesNamesJSON};
                 var responseTimeSeriesValues = ${it.percentileResponseTimeGraph.seriesJSON};
 
-                jQuery('#responseTimePercentile').bind('jqplotDataClick',
+                jQueryGatling('#responseTimePercentile').bind('jqplotDataClick',
                     function (ev, seriesIndex, pointIndex, data) {
                         var xAxisArray = responseTimeSeriesValues[seriesIndex].reverse();
                         var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + responseTimeSeriesNames[seriesIndex].label + "/";
@@ -60,7 +60,7 @@
                 var requestKOSeriesNames = ${it.requestKOPercentageGraph.seriesNamesJSON};
                 var requestKOSeriesValues = ${it.requestKOPercentageGraph.seriesJSON};
 
-                jQuery('#requestKO').bind('jqplotDataClick',
+                jQueryGatling('#requestKO').bind('jqplotDataClick',
                     function (ev, seriesIndex, pointIndex, data) {
                         var xAxisArray = responseTimeSeriesValues[seriesIndex].reverse();
                         var url = "../" + xAxisArray[pointIndex][0] + "/gatling/report/" + requestKOSeriesNames[seriesIndex].label + "/";

--- a/src/main/resources/io/gatling/jenkins/tags/graph.jelly
+++ b/src/main/resources/io/gatling/jenkins/tags/graph.jelly
@@ -25,14 +25,14 @@
 	</st:documentation>
 	<div id="${attrs.id}" style="width: ${attrs.width};height: ${attrs.height};">
 		<script type="text/javascript" language="javascript">
-			jQuery.noConflict();
-			jQuery(document).ready(function () {
-				var plot1 = jQuery.jqplot('${attrs.id}', ${attrs.data}, {
+			jQueryGatling.noConflict();
+			jQueryGatling(document).ready(function () {
+				var plot1 = jQueryGatling.jqplot('${attrs.id}', ${attrs.data}, {
 					title:"${attrs.title}",
 					series: ${attrs.seriesNames},
 					axes:{
 						xaxis:{
-							renderer:jQuery.jqplot.CategoryAxisRenderer,
+							renderer:jQueryGatling.jqplot.CategoryAxisRenderer,
 							rendererOptions:{sortMergedLabels:true, tickOptions:{
 								formatString:'#%d'
 							}},

--- a/src/main/resources/io/gatling/jenkins/tags/import.jelly
+++ b/src/main/resources/io/gatling/jenkins/tags/import.jelly
@@ -8,5 +8,6 @@
 	<script type="text/javascript" src="${rootURL}/plugin/gatling/js/jqplot/plugins/jqplot.cursor.min.js"></script>
 	<script type="text/javascript"
 	        src="${rootURL}/plugin/gatling/js/jqplot/plugins/jqplot.categoryAxisRenderer.min.js"></script>
+	<script type="text/javascript">window.jQueryGatling = jQuery.noConflict()</script>
 	<link rel="stylesheet" type="text/css" href="${rootURL}/plugin/gatling/js/jqplot/jquery.jqplot.min.css"/>
 </j:jelly>


### PR DESCRIPTION
As mentioned in gatling/gatling#2792, there's a conflict when Jenkins has both the Gatling plugin installed as well as the [jquery-jenkins-plugin](https://wiki.jenkins-ci.org/display/JENKINS/jQuery+Plugin). This Gatling plugin loads jQuery 1.8.1, attaches `jqplot` to it, and then the jquery-jenkins-plugin loads jQuery 1.11.2 again, which of course overwrites `window.jQuery`, and then later on in the page Gatling tries to reference `jQuery.jqplot` with expectable results. 

```html
<!-- from our import.jelly -->
<script src="/jenkins/plugin/gatling/js/jquery.min.js" language="javascript" type="text/javascript"></script>
<script src="/jenkins/plugin/gatling/js/jqplot/jquery.jqplot.min.js" language="javascript" type="text/javascript"></script>
<script src="/jenkins/plugin/gatling/js/jqplot/plugins/jqplot.highlighter.min.js" type="text/javascript"></script>
<script src="/jenkins/plugin/gatling/js/jqplot/plugins/jqplot.cursor.min.js" type="text/javascript"></script>
<script src="/jenkins/plugin/gatling/js/jqplot/plugins/jqplot.categoryAxisRenderer.min.js" type="text/javascript"></script>
<link rel="stylesheet" type="text/css" href="/jenkins/plugin/gatling/js/jqplot/jquery.jqplot.min.css" />
<!-- from the jquery-jenkins-plugin, resets window.jQuery, deleting jQuery.jqplot -->
<script src="/jenkins/adjuncts/4676e4d9/org/kohsuke/stapler/jquery/jquery.full.js" type="text/javascript"></script>
<script>var Q=jQuery.noConflict()</script>
```

The hacky fix in this PR is to deliberately disambiguate our jQuery from the jQuery that the jquery-jenkins-plugin loads by putting it in a separate global variable.

In theory we should be able to use the jquery-jenkins-plugin, but I tried it locally and there [seem to be some version conflicts](http://take.ms/oqusH): the Gatling plugin & its jqPlot stuff expects jQuery 1.8.1, but the jquery-jenkins-plugin uses ver 1.11.2, which leads to some console errors about `msie`, `push`, etc, which appear to have changed across jQuery versions. I wasn't very interested in digging into jqplot & jQuery version compat.

I also tried holding on to `jQuery.jqplot` and reassigning the `.jqplot` property after the reset, and while that worked to bring the graphs back, the points on the graphs were no longer clickable to open a new tab. Also, this would require loading the Gatling plugin's `import.jelly` after jquery-jenkins-plugin's `import.jelly`, which I'm not sure how to do.

edit: oh, perhaps a slightly cleaner workaround: wrap all of our JS in an IIFE that takes `jQueryGatling` as its argument, and internally references it as `jQuery` ?