### PR TITLE
Add support for Jenkins Pipeline jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.494</version>
+		<version>2.3</version>
 	</parent>
 
 	<artifactId>gatling</artifactId>
@@ -21,9 +21,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git@github.com:jenkinsci/gatling-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/gatling-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/gatling-plugin</url>
+		<connection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -52,6 +52,19 @@
 	</developers>
 
 	<properties>
+		<!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to
+    run. -->
+		<jenkins.version>1.651.2</jenkins.version>
+		<!-- Java Level to use. Java 7 required when using core >= 1.612 -->
+		<java.level>7</java.level>
+		<!-- Jenkins Test Harness version you use to test the plugin. -->
+		<!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
+		<jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+		<!-- Other properties you may want to use:
+             ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
+             ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
+        -->
+
 		<jackson.version>2.4.4</jackson.version>
 
 		<maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
@@ -82,6 +95,31 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
+		</dependency>
+
+		<!-- dependencies on Jenkins Pipeline plugins -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-job</artifactId>
+			<version>1.14</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<version>1.14</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-step-api</artifactId>
+			<version>1.14</version>
+		</dependency>
+
+		<!-- writeFile is useful for test -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-basic-steps</artifactId>
+			<version>1.14</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/io/gatling/jenkins/GatlingProjectAction.java
+++ b/src/main/java/io/gatling/jenkins/GatlingProjectAction.java
@@ -17,9 +17,7 @@ package io.gatling.jenkins;
 
 import static io.gatling.jenkins.PluginConstants.*;
 
-import hudson.model.Action;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.*;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -30,9 +28,9 @@ import io.gatling.jenkins.chart.Graph;
 
 public class GatlingProjectAction implements Action {
 
-  private final AbstractProject<?, ?> project;
+  private final Job<?, ?> project;
 
-  public GatlingProjectAction(AbstractProject<?, ?> project) {
+  public GatlingProjectAction(Job<?, ?> project) {
     this.project = project;
   }
 
@@ -48,12 +46,12 @@ public class GatlingProjectAction implements Action {
     return URL_NAME;
   }
 
-  public AbstractProject<?, ?> getProject() {
+  public Job<?, ?> getProject() {
     return project;
   }
 
   public boolean isVisible() {
-    for (AbstractBuild<?, ?> build : getProject().getBuilds()) {
+    for (Run<?, ?> build : getProject().getBuilds()) {
       GatlingBuildAction gatlingBuildAction = build.getAction(GatlingBuildAction.class);
       if (gatlingBuildAction != null) {
         return true;
@@ -98,10 +96,10 @@ public class GatlingProjectAction implements Action {
     };
   }
 
-  public Map<AbstractBuild<?, ?>, List<String>> getReports() {
-    Map<AbstractBuild<?, ?>, List<String>> reports = new LinkedHashMap<AbstractBuild<?, ?>, List<String>>();
+  public Map<Run<?, ?>, List<String>> getReports() {
+    Map<Run<?, ?>, List<String>> reports = new LinkedHashMap<Run<?, ?>, List<String>>();
 
-    for (AbstractBuild<?, ?> build : project.getBuilds()) {
+    for (Run<?, ?> build : project.getBuilds()) {
       GatlingBuildAction action = build.getAction(GatlingBuildAction.class);
       if (action != null) {
         List<String> simNames = new ArrayList<String>();

--- a/src/main/java/io/gatling/jenkins/chart/Graph.java
+++ b/src/main/java/io/gatling/jenkins/chart/Graph.java
@@ -15,15 +15,14 @@
  */
 package io.gatling.jenkins.chart;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-
 import java.io.IOException;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.model.Job;
+import hudson.model.Run;
 import io.gatling.jenkins.GatlingBuildAction;
 import io.gatling.jenkins.BuildSimulation;
 import io.gatling.jenkins.RequestReport;
@@ -36,9 +35,9 @@ public abstract class Graph<Y extends Number> {
 
   private final ObjectMapper mapper = new ObjectMapper();
 
-  public Graph(AbstractProject<?, ?> project, int maxBuildsToDisplay) {
+  public Graph(Job<?, ?> project, int maxBuildsToDisplay) {
     int numberOfBuild = 0;
-    for (AbstractBuild<?, ?> build : project.getBuilds()) {
+    for (Run<?, ?> build : project.getBuilds()) {
       GatlingBuildAction action = build.getAction(GatlingBuildAction.class);
 
       if (action != null) {

--- a/src/main/java/io/gatling/jenkins/steps/GatlingArchiverStep.java
+++ b/src/main/java/io/gatling/jenkins/steps/GatlingArchiverStep.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2011-2015 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.jenkins.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Archiving for gatling reports.
+ */
+public class GatlingArchiverStep extends AbstractStepImpl {
+    @DataBoundConstructor
+    public GatlingArchiverStep() {}
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() { super(GatlingArchiverStepExecution.class); }
+
+        @Override
+        public String getFunctionName() {
+            return "gatlingArchive";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Archive Gatling reports";
+        }
+    }
+}

--- a/src/main/java/io/gatling/jenkins/steps/GatlingArchiverStepExecution.java
+++ b/src/main/java/io/gatling/jenkins/steps/GatlingArchiverStepExecution.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2011-2015 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.jenkins.steps;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.gatling.jenkins.GatlingPublisher;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+public class GatlingArchiverStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+    @StepContextParameter
+    private transient TaskListener listener;
+
+    @StepContextParameter
+    private transient FilePath ws;
+
+    @StepContextParameter
+    private transient Run build;
+
+    @StepContextParameter
+    private transient Launcher launcher;
+
+    @Override
+    protected Void run() throws Exception {
+        listener.getLogger().println("Running Gatling archiver step.");
+
+        GatlingPublisher publisher = new GatlingPublisher(true);
+        publisher.perform(build, ws, launcher, listener);
+
+        return null;
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
-
+<?jelly escape-by-default='true'?>
 <div>
   This plugin integrates Gatling simulation reports into Jenkins.
 </div>

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/index.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:l="/lib/layout">
 	<l:layout title="Build #${it.build.number}">

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/report.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/report.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:l="/lib/layout">
 	<l:layout title="Build #${it.build.number} : ${simName}">
@@ -6,17 +7,17 @@
 			<st:include it="${it.build}" page="sidepanel.jelly"/>
 		</l:side-panel>
 		<l:main-panel>
-			<h1>
-				<a href="source" target="_blank">${%OpenNewPage}</a>
-			</h1>
-			<iframe id="reportFrame" sandbox="allow-scripts" src="source" width="100%" height="100%" frameborder="0"
-			        onload="resizeReportFrame()"></iframe>
 			<script type="text/javascript">
 				function resizeReportFrame() {
 					var frame = document.getElementById("reportFrame")
 					frame.height = frame.contentWindow.document.body.scrollHeight + "px"
 				}
 			</script>
+			<h3>
+				<a href="source" target="_blank">${%OpenNewPage}</a>
+			</h3>
+			<iframe id="reportFrame" src="source" width="100%" height="100%" frameborder="0"
+					onload="resizeReportFrame()"></iframe>
 		</l:main-panel>
 	</l:layout>
 </j:jelly>

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/report.properties
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/report.properties
@@ -1,1 +1,1 @@
-OpenNewPage=Open in a new page.
+OpenNewPage=Open in a new window

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+         xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <t:summary icon="/plugin/gatling/img/logo.png">
+        <b>${%AvailableReports} :</b>
+        <ul>
+            <j:forEach items="${it.simulations}" var="sim">
+                <li>
+                    <a href="${it.getReportURL(sim.simulationName)}">${sim.simulationName}</a>
+                </li>
+            </j:forEach>
+        </ul>
+    </t:summary>
+</j:jelly>

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.properties
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.properties
@@ -1,0 +1,1 @@
+AvailableReports=Available reports for this build

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary_fr.properties
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary_fr.properties
@@ -1,0 +1,1 @@
+AvailableReports=Rapports disponibles pour ce build

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/floatingBox.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:g="/io/gatling/jenkins/tags">
 	<j:if test="${action.isVisible()}">
 		<g:import/>

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/index.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
          xmlns:g="/io/gatling/jenkins/tags">
 	<l:layout title="${it.project.name} - ${%ProjectPageTitle}">

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/mean_json.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/mean_json.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
          xmlns:g="/io/gatling/jenkins/tags">
   ${it.meanResponseTimeGraph.seriesJSON}

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/per95_json.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/per95_json.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
          xmlns:g="/io/gatling/jenkins/tags">
   ${it.percentileResponseTimeGraph.seriesJSON}

--- a/src/main/resources/io/gatling/jenkins/GatlingProjectAction/reqKO_json.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingProjectAction/reqKO_json.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:fmt="jelly:fmt" xmlns:l="/lib/layout"
          xmlns:g="/io/gatling/jenkins/tags">
   ${it.requestKOPercentageGraph.seriesJSON}

--- a/src/main/resources/io/gatling/jenkins/GatlingPublisher/config.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 	<f:entry>
 		<f:checkbox field="enabled" default="true" value="${instance.enabled}" title="${%Enabled}"/>

--- a/src/main/resources/io/gatling/jenkins/Messages.properties
+++ b/src/main/resources/io/gatling/jenkins/Messages.properties
@@ -1,1 +1,1 @@
-Title=Track a Gatling load simulation
+title=Track a Gatling load simulation

--- a/src/main/resources/io/gatling/jenkins/Messages_fr.properties
+++ b/src/main/resources/io/gatling/jenkins/Messages_fr.properties
@@ -1,1 +1,1 @@
-Title=Suivre une simulation Gatling
+title=Suivre une simulation Gatling

--- a/src/main/resources/io/gatling/jenkins/steps/GatlingArchiverStep/config.jelly
+++ b/src/main/resources/io/gatling/jenkins/steps/GatlingArchiverStep/config.jelly
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- this is where we'd put the GUI for configuration options
+         for the GatlingArchiverStep, if we had any.  This will
+         show up in the Groovy snippet generator. -->
+</j:jelly>

--- a/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
+++ b/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2011-2015 GatlingCorp (http://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gatling.jenkins.steps;
+
+import hudson.model.Action;
+import io.gatling.jenkins.GatlingBuildAction;
+import jenkins.util.VirtualFile;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GatlingArchiverStepTest extends Assert {
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Test archiving of gatling reports
+     */
+    @Test
+    public void archive() throws Exception {
+        // job setup
+        WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
+        foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList(
+                "node {",
+                "  writeFile file: 'results/foo-1234/js/global_stats.json', text: '{}'",
+                "  writeFile file: 'results/bar-5678/js/global_stats.json', text: '{}'",
+                "  gatlingArchive()",
+                "}"), "\n")));
+
+        // get the build going, and wait until workflow pauses
+        WorkflowRun b = j.assertBuildStatusSuccess(foo.scheduleBuild2(0).get());
+
+        File fooArchiveDir = new File(b.getRootDir(), "simulations/foo-1234");
+        assertTrue("foo archive dir doesn't exist: " + fooArchiveDir,
+                fooArchiveDir.isDirectory());
+        File barArchiveDir = new File(b.getRootDir(), "simulations/bar-5678");
+        assertTrue("bar archive dir doesn't exist: " + barArchiveDir,
+                barArchiveDir.isDirectory());
+
+        List<GatlingBuildAction> gbas = new ArrayList<>();
+        for (Action a : b.getAllActions()) {
+            if (a instanceof GatlingBuildAction) {
+                gbas.add((GatlingBuildAction) a);
+            }
+        }
+        assertEquals("Should be exactly one GatlingBuildAction",
+                1, gbas.size());
+
+        GatlingBuildAction buildAction = gbas.get(0);
+        assertEquals("BuildAction should have exactly one ProjectAction",
+                1, buildAction.getProjectActions().size());
+    }
+}
+


### PR DESCRIPTION
With these commits, the plugin can now be used from Jenkins Pipeline jobs, by adding a line like this to your pipeline build script:

    gatlingArchive()