### PR TITLE
[JENKINS-50977, JENKINS-51014] - Stop persisting Logger and Run references in GatlingPublisher

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, "2.107.2"])

--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,6 @@
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-cps</artifactId>
 			<version>1.14</version>
-			<exclusions> <!-- TODO: remove once updated to newer Jenkins baseline and Pipeline versions -->
-				<exclusion>
-					<groupId>org.jenkins-ci.ui</groupId>
-					<artifactId>jquery-detached</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -289,6 +283,23 @@
 				<configuration>
 					<hpiName>${project.build.finalName}-${project.version}</hpiName>
 				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>display-info</id>
+						<configuration>
+							<rules>
+								<enforceBytecodeVersion>
+									<excludes combine.children="append">
+										<exclude>org.jenkins-ci.ui:jquery-detached</exclude>
+									</excludes>
+								</enforceBytecodeVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>2.9</version>
+		<version>3.8</version>
 	</parent>
 
 	<artifactId>gatling</artifactId>
 	<version>1.2.3-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 	<name>Gatling Jenkins Plugin</name>
-	<url>https://wiki.jenkins-ci.org/display/JENKINS/Gatling+Plugin</url>
+	<url>https://wiki.jenkins.io/display/JENKINS/Gatling+Plugin</url>
 
 	<licenses>
 		<license>
@@ -54,15 +54,6 @@
 		<jenkins.version>1.651.2</jenkins.version>
 		<!-- Java Level to use. Java 7 required when using core >= 1.612 -->
 		<java.level>7</java.level>
-		<!-- Jenkins Test Harness version you use to test the plugin. -->
-		<!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-		<jenkins-test-harness.version>2.1</jenkins-test-harness.version>
-		<!-- Other properties you may want to use:
-             ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-             ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-        -->
-
-		<jackson.version>2.4.4</jackson.version>
 
 		<maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
 		<maven-source-plugin.version>2.2</maven-source-plugin.version>
@@ -76,14 +67,14 @@
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 
@@ -109,6 +100,12 @@
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-step-api</artifactId>
 			<version>1.14</version>
+		</dependency>
+		<!-- Required due to JENKINS-51013 in plugin compat tester -->
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>script-security</artifactId>
+			<version>1.18.1</version>
 		</dependency>
 
 		<!-- writeFile is useful for test -->

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<!--TODO: pick newer version once baseline is updated to Java8-->
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>jackson2-api</artifactId>
+			<version>2.7.3</version>
 		</dependency>
 
 		<!-- dependencies on Jenkins Pipeline plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -291,11 +291,12 @@
 						<id>display-info</id>
 						<configuration>
 							<rules>
-								<enforceBytecodeVersion>
+								<requireUpperBoundDeps>
 									<excludes combine.children="append">
+										<!-- workflow-cps requests 1.1.1, core 2.60.1+ requests 1.2.1 -->
 										<exclude>org.jenkins-ci.ui:jquery-detached</exclude>
 									</excludes>
-								</enforceBytecodeVersion>
+								</requireUpperBoundDeps>
 							</rules>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 			<version>1.18.1</version>
 		</dependency>
 
-		<!-- writeFile is useful for test -->
+		<!-- writeFile and sleep are useful for test -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-basic-steps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-cps</artifactId>
 			<version>1.14</version>
+			<exclusions> <!-- TODO: remove once updated to newer Jenkins baseline and Pipeline versions -->
+				<exclusion>
+					<groupId>org.jenkins-ci.ui</groupId>
+					<artifactId>jquery-detached</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
+++ b/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
@@ -62,7 +62,7 @@ public class GatlingArchiverStepTest extends Assert {
 
         // get the build going, and wait until workflow pauses
         WorkflowRun b = j.assertBuildStatusSuccess(foo.scheduleBuild2(0).get());
-        verifyResult(b, null);
+        verifyResult(b);
     }
 
     @Test
@@ -85,15 +85,13 @@ public class GatlingArchiverStepTest extends Assert {
 
         // Build and assert status
         FreeStyleBuild freeStyleBuild = j.buildAndAssertSuccess(foo);
-        verifyResult(freeStyleBuild, freeStyleBuild.getWorkspace());
+        verifyResult(freeStyleBuild);
 
         // Triggers JEP-200 if PrintStream is still persisted
         foo.save();
     }
 
-    private void verifyResult(Run b, @CheckForNull FilePath workspace) {
-        // Runs in assumption that agent is actually local
-        //File baseDir = workspace != null ? new File(workspace.getRemote()) : b.getRootDir();
+    private void verifyResult(Run b) {
         File baseDir = b.getRootDir();
         File fooArchiveDir = new File(baseDir, "simulations/foo-1234");
         assertTrue("foo archive dir doesn't exist: " + fooArchiveDir,

--- a/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
+++ b/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
@@ -55,6 +55,7 @@ public class GatlingArchiverStepTest extends Assert {
         WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
         foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList(
                 "node {",
+                "  sleep 1", // JENKINS-51015
                 "  writeFile file: 'results/foo-1234/js/global_stats.json', text: '{}'",
                 "  writeFile file: 'results/bar-5678/js/global_stats.json', text: '{}'",
                 "  gatlingArchive()",
@@ -75,7 +76,7 @@ public class GatlingArchiverStepTest extends Assert {
 
         foo.setAssignedNode(onlineSlave);
         foo.getBuildersList().add(new Shell("\n" +
-                "sleep 1 \n" + // Otherwise GatlingPublisher skips that because BuildStart time has second-accuracy
+                "sleep 1 \n" + // Otherwise GatlingPublisher skips that because BuildStart time has second-accuracy (JENKINS-51015)
                 "mkdir -p results/foo-1234/js/\n" +
                 "echo '{}' > results/foo-1234/js/global_stats.json\n" +
                 "mkdir -p results/bar-5678/js/\n" +


### PR DESCRIPTION
In some conditions the plugin may fail in Jenkins 2.102+. In any publisher step (like project description setter) saves Job configuration after Gatling Publisher, the plugin will try to serialize non-whitelisted classes to the disk. This PR fixes that and also does some facelifting job.

* https://issues.jenkins-ci.org/browse/JENKINS-50977
* https://issues.jenkins-ci.org/browse/JENKINS-51014

- [x] - Add Jenkinsfile so that CI runs on ci.jenkins.io
- [x] - Use the latest plugin POM, enable testing with [Plugin Compat Tester](https://github.com/jenkinsci/plugin-compat-tester)
- [x] - Use Jackson from an API plugin instead of bundling it in HPI
- [x] - Fix the issues, actually

@reviewbybees @jglick @ccedric  @slandelle 