### PR TITLE
support multiple simulations with the same name per build

### DIFF
--- a/src/main/java/io/gatling/jenkins/GatlingBuildAction.java
+++ b/src/main/java/io/gatling/jenkins/GatlingBuildAction.java
@@ -71,25 +71,25 @@ public class GatlingBuildAction implements Action, SimpleBuildStep.LastBuildActi
 
   /**
    * This method is called dynamically for any HTTP request to our plugin's
-   * URL followed by "/report/SomeSimulationName".
+   * URL followed by "/report/reportName".
    *
    * It returns a new instance of {@link ReportRenderer}, which contains the
    * actual logic for rendering a report.
    *
-   * @param simulationName the name of the simulation
+   * @param reportName the name of the reportName
    */
-  public ReportRenderer getReport(String simulationName) {
-    return new ReportRenderer(this, getSimulation(simulationName));
+  public ReportRenderer getReport(String reportName) {
+    return new ReportRenderer(this, getSimulationByReportName(reportName));
   }
 
-  public String getReportURL(String simulationName) {
-    return new StringBuilder().append(URL_NAME).append("/report/").append(simulationName).toString();
+  public String getReportURL(BuildSimulation simulation) {
+    return new StringBuilder().append(URL_NAME).append("/report/").append(simulation.getSimulationDirectory().getName()).toString();
   }
 
-  private BuildSimulation getSimulation(String simulationName) {
+  private BuildSimulation getSimulationByReportName(String reportName) {
     // this isn't the most efficient implementation in the world :)
     for (BuildSimulation sim : this.getSimulations()) {
-      if (sim.getSimulationName().equals(simulationName)) {
+      if (sim.getSimulationDirectory().getName().equals(reportName)) {
         return sim;
       }
     }

--- a/src/main/java/io/gatling/jenkins/GatlingProjectAction.java
+++ b/src/main/java/io/gatling/jenkins/GatlingProjectAction.java
@@ -104,7 +104,7 @@ public class GatlingProjectAction implements Action {
       if (action != null) {
         List<String> simNames = new ArrayList<String>();
         for (BuildSimulation sim : action.getSimulations()) {
-          simNames.add(sim.getSimulationName());
+          simNames.add(sim.getSimulationDirectory().getName());
         }
         reports.put(build, simNames);
       }

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/index.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/index.jelly
@@ -10,7 +10,7 @@
             <ul>
                 <j:forEach items="${it.simulations}" var="sim">
                     <li>
-                        <a href="../${it.getReportURL(sim.simulationName)}" target="_blank">${sim.simulationName}</a>
+                        <a href="../${it.getReportURL(sim)}" target="_blank">${sim.getSimulationDirectory().getName()}</a>
                     </li>
                 </j:forEach>
             </ul>

--- a/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.jelly
+++ b/src/main/resources/io/gatling/jenkins/GatlingBuildAction/summary.jelly
@@ -7,7 +7,7 @@
         <ul>
             <j:forEach items="${it.simulations}" var="sim">
                 <li>
-                    <a href="${it.getReportURL(sim.simulationName)}">${sim.simulationName}</a>
+                    <a href="${it.getReportURL(sim)}">${sim.getSimulationDirectory().getName()}</a>
                 </li>
             </j:forEach>
         </ul>

--- a/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
+++ b/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
@@ -15,8 +15,6 @@
  */
 package io.gatling.jenkins.steps;
 
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -25,7 +23,6 @@ import hudson.slaves.DumbSlave;
 import hudson.tasks.Shell;
 import io.gatling.jenkins.GatlingBuildAction;
 import io.gatling.jenkins.GatlingPublisher;
-import jenkins.util.VirtualFile;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -37,14 +34,14 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import javax.annotation.CheckForNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class GatlingArchiverStepTest extends Assert {
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     /**
      * Test archiving of gatling reports
@@ -57,6 +54,7 @@ public class GatlingArchiverStepTest extends Assert {
                 "node {",
                 "  sleep 1", // JENKINS-51015
                 "  writeFile file: 'results/foo-1234/js/global_stats.json', text: '{}'",
+                "  writeFile file: 'results/foo-4321/js/global_stats.json', text: '{}'",
                 "  writeFile file: 'results/bar-5678/js/global_stats.json', text: '{}'",
                 "  gatlingArchive()",
                 "}"), "\n")));
@@ -79,6 +77,8 @@ public class GatlingArchiverStepTest extends Assert {
                 "sleep 1 \n" + // Otherwise GatlingPublisher skips that because BuildStart time has second-accuracy (JENKINS-51015)
                 "mkdir -p results/foo-1234/js/\n" +
                 "echo '{}' > results/foo-1234/js/global_stats.json\n" +
+                "mkdir -p results/foo-4321/js/\n" +
+                "echo '{}' > results/foo-4321/js/global_stats.json\n" +
                 "mkdir -p results/bar-5678/js/\n" +
                 "echo '{}' > results/bar-5678/js/global_stats.json\n"
         ));
@@ -95,11 +95,13 @@ public class GatlingArchiverStepTest extends Assert {
     private void verifyResult(Run b) {
         File baseDir = b.getRootDir();
         File fooArchiveDir = new File(baseDir, "simulations/foo-1234");
-        assertTrue("foo archive dir doesn't exist: " + fooArchiveDir,
-                fooArchiveDir.isDirectory());
+        assertTrue("foo archive dir doesn't exist: " + fooArchiveDir, fooArchiveDir.isDirectory());
+
+        File foo2ArchiveDir = new File(baseDir, "simulations/foo-4321");
+        assertTrue("foo archive dir doesn't exist: " + foo2ArchiveDir, foo2ArchiveDir.isDirectory());
+
         File barArchiveDir = new File(baseDir, "simulations/bar-5678");
-        assertTrue("bar archive dir doesn't exist: " + barArchiveDir,
-                barArchiveDir.isDirectory());
+        assertTrue("bar archive dir doesn't exist: " + barArchiveDir, barArchiveDir.isDirectory());
 
         List<GatlingBuildAction> gbas = new ArrayList<>();
         for (Action a : b.getAllActions()) {
@@ -107,12 +109,10 @@ public class GatlingArchiverStepTest extends Assert {
                 gbas.add((GatlingBuildAction) a);
             }
         }
-        assertEquals("Should be exactly one GatlingBuildAction",
-                1, gbas.size());
+        assertEquals("Should be exactly one GatlingBuildAction", 1, gbas.size());
 
         GatlingBuildAction buildAction = gbas.get(0);
-        assertEquals("BuildAction should have exactly one ProjectAction",
-                1, buildAction.getProjectActions().size());
+        assertEquals("BuildAction should have exactly one ProjectAction", 1, buildAction.getProjectActions().size());
     }
 }
 


### PR DESCRIPTION
As reported by ShettyA here: https://github.com/gatling/gatling/issues/1162#issuecomment-73151131
Multiple gatling runs with the same name in the same build are not supported, because multiple build Simulations are created with the same name.
This change aims to create the simulations with the report's folder name, bypassing the issue.
