### PR TITLE
fix broken dot url on graph, closes #3505

### DIFF
--- a/src/main/java/io/gatling/jenkins/chart/Graph.java
+++ b/src/main/java/io/gatling/jenkins/chart/Graph.java
@@ -43,7 +43,7 @@ public abstract class Graph<Y extends Number> {
       if (action != null) {
         numberOfBuild++;
         for (BuildSimulation sim : action.getSimulations()) {
-          SerieName name = new SerieName(sim.getSimulationName());
+          SerieName name = new SerieName(sim.getSimulationName(), sim.getSimulationDirectory().getName());
           if (!series.containsKey(name))
             series.put(name, new Serie<Integer, Y>());
 

--- a/src/main/java/io/gatling/jenkins/chart/SerieName.java
+++ b/src/main/java/io/gatling/jenkins/chart/SerieName.java
@@ -24,15 +24,17 @@ import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 
 public class SerieName implements JsonSerializable, Comparable<SerieName> {
   final String name;
+  final String path;
 
-  public SerieName(String name) {
+  public SerieName(String name, String path) {
     this.name = name;
+    this.path = path;
   }
 
   public void serialize(JsonGenerator jgen, SerializerProvider provider) throws IOException {
     jgen.disable(JsonGenerator.Feature.QUOTE_FIELD_NAMES);
     jgen.writeStartObject();
-    jgen.writeStringField("label", name);
+    jgen.writeStringField("label", path);
     jgen.writeEndObject();
   }
 


### PR DESCRIPTION
Fixes https://github.com/gatling/gatling/issues/3505

I realized that the only thing that is broken is the url. 
First, I changed `sim.getSimulationName()` with `sim.getSimulationDirectory().getName()` without adding additional parameter to SerieName class but it broke the graph. Basically, graph started to identify all simulations as `seperate` simulations and there were no connection between dots. So, I decided to pass the path as an extra variable and assigned to `label` which will be used to construct dot url.

Hope it does not cause any side affects!