### PR TITLE
[JENKINS-57244] Do not serialize a FilePath to build.xml

### DIFF
--- a/src/main/java/io/gatling/jenkins/BuildSimulation.java
+++ b/src/main/java/io/gatling/jenkins/BuildSimulation.java
@@ -16,6 +16,7 @@
 package io.gatling.jenkins;
 
 import hudson.FilePath;
+import java.io.File;
 
 /**
  * This class is basically just a struct to hold information about one
@@ -25,12 +26,22 @@ import hudson.FilePath;
 public class BuildSimulation {
   private final String simulationName;
   private final RequestReport requestReport;
-  private final FilePath simulationDirectory;
+  @Deprecated
+  private transient FilePath simulationDirectory;
+  // TODO better to save, for example, a relative path from Run.rootDir
+  private File simulationPath;
 
-  public BuildSimulation(String simulationName, RequestReport requestReport, FilePath simulationDirectory) {
+  public BuildSimulation(String simulationName, RequestReport requestReport, File simulationPath) {
     this.simulationName = simulationName;
     this.requestReport = requestReport;
-    this.simulationDirectory = simulationDirectory;
+    this.simulationPath = simulationPath;
+  }
+
+  private Object readResolve() {
+    if (simulationDirectory != null) {
+        simulationPath = new File(simulationDirectory.getRemote());
+    }
+    return this;
   }
 
   public String getSimulationName() {
@@ -41,7 +52,7 @@ public class BuildSimulation {
     return requestReport;
   }
 
-  public FilePath getSimulationDirectory() {
-    return simulationDirectory;
+  public File getSimulationDirectory() {
+    return simulationPath;
   }
 }

--- a/src/main/java/io/gatling/jenkins/GatlingBuildAction.java
+++ b/src/main/java/io/gatling/jenkins/GatlingBuildAction.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 public class GatlingBuildAction implements Action, SimpleBuildStep.LastBuildAction {
 
-  private final Run<?, ?> run;
+  private final Run<?, ?> run; // TODO make transient, implement RunAction2
   private final List<BuildSimulation> simulations;
 
   public GatlingBuildAction(Run<?, ?> run, List<BuildSimulation> sims) {

--- a/src/main/java/io/gatling/jenkins/GatlingPublisher.java
+++ b/src/main/java/io/gatling/jenkins/GatlingPublisher.java
@@ -165,7 +165,7 @@ public class GatlingPublisher extends Recorder implements SimpleBuildStep {
 
       SimulationReport report = new SimulationReport(reportDirectory, simulation);
       report.readStatsFile();
-      BuildSimulation sim = new BuildSimulation(simulation, report.getGlobalReport(), reportDirectory);
+      BuildSimulation sim = new BuildSimulation(simulation, report.getGlobalReport(), simulationDirectory);
 
       simsToArchive.add(sim);
     }

--- a/src/main/java/io/gatling/jenkins/ReportRenderer.java
+++ b/src/main/java/io/gatling/jenkins/ReportRenderer.java
@@ -15,6 +15,7 @@
  */
 package io.gatling.jenkins;
 
+import hudson.FilePath;
 import hudson.model.Action;
 import hudson.model.DirectoryBrowserSupport;
 import org.kohsuke.stapler.ForwardToView;
@@ -47,7 +48,7 @@ public class ReportRenderer {
     this.action = gatlingBuildAction;
     this.simulation = simulation;
 
-    File rootDir = new File(simulation.getSimulationDirectory().getRemote());
+    File rootDir = simulation.getSimulationDirectory();
     this.safeDirectories = unmodifiableSet(new HashSet<>(asList(
             rootDir,
             new File(rootDir, "js"),
@@ -88,7 +89,7 @@ public class ReportRenderer {
    */
   public void doSource(StaplerRequest request, StaplerResponse response)
     throws IOException, ServletException {
-    String dir = simulation.getSimulationDirectory().getRemote();
+    File dir = simulation.getSimulationDirectory();
     String fileName = request.getRestOfPath();
     if (fileName.isEmpty()) {
       // serve the index page
@@ -104,7 +105,7 @@ public class ReportRenderer {
       }
     } else {
       DirectoryBrowserSupport dbs = new DirectoryBrowserSupport(action,
-              simulation.getSimulationDirectory(),
+              new FilePath(simulation.getSimulationDirectory()),
               simulation.getSimulationName(), null, false);
       dbs.generateResponse(request, response, action);
     }

--- a/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
+++ b/src/test/java/io/gatling/jenkins/steps/GatlingArchiverStepTest.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
 
 public class GatlingArchiverStepTest extends Assert {
     @Rule
@@ -92,7 +93,7 @@ public class GatlingArchiverStepTest extends Assert {
         foo.save();
     }
 
-    private void verifyResult(Run b) {
+    private void verifyResult(Run b) throws Exception {
         File baseDir = b.getRootDir();
         File fooArchiveDir = new File(baseDir, "simulations/foo-1234");
         assertTrue("foo archive dir doesn't exist: " + fooArchiveDir, fooArchiveDir.isDirectory());
@@ -113,6 +114,9 @@ public class GatlingArchiverStepTest extends Assert {
 
         GatlingBuildAction buildAction = gbas.get(0);
         assertEquals("BuildAction should have exactly one ProjectAction", 1, buildAction.getProjectActions().size());
+
+        // TODO JENKINS-57244 use RestartableJenkinsRule to verify that the action was actually saved successfully
+        FileUtils.copyFile(new File(b.getRootDir(), "build.xml"), System.out);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/gatling/gatling/issues/3722. See http://github.com/jenkinsci/jenkins/pull/4011 for amelioration. Not really tested except to the effect that `GatlingArchiverStepTest` no longer prints errors under `-Djenkins.version=2.175`.