### PR TITLE
Fixes: https://github.com/gatling/gatling/issues/3816

### DIFF
--- a/src/main/java/io/gatling/jenkins/GatlingPublisher.java
+++ b/src/main/java/io/gatling/jenkins/GatlingPublisher.java
@@ -69,13 +69,23 @@ public class GatlingPublisher extends Recorder implements SimpleBuildStep {
         return true;
       }
 
-      GatlingBuildAction action = new GatlingBuildAction(build, sims);
+      addOrUpdateBuildAction(build, sims);
 
-      build.addAction(action);
       return true;
     } else {
       logger.println("Failed to access workspace, it may be on a non-connected slave.");
       return false;
+    }
+  }
+
+  private void addOrUpdateBuildAction(@Nonnull Run<?, ?> run, List<BuildSimulation> simulations) {
+    GatlingBuildAction action = run.getAction(GatlingBuildAction.class);
+
+    if (action != null) {
+      action.getSimulations().addAll(simulations);
+    } else {
+      action = new GatlingBuildAction(run, simulations);
+      run.addAction(action);
     }
   }
 
@@ -101,9 +111,7 @@ public class GatlingPublisher extends Recorder implements SimpleBuildStep {
       return;
     }
 
-    GatlingBuildAction action = new GatlingBuildAction(run, sims);
-
-    run.addAction(action);
+    addOrUpdateBuildAction(run, sims);
   }
 
   public boolean isEnabled() {


### PR DESCRIPTION
Current design of plugin uses a single build action for gatling.
This breaks down when a simulation is uploaded during multiple build steps.
We can update the action if one is already present, or create one if one is not present yet.